### PR TITLE
Upgrade to version 2 of AWS SDK

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "http://rubygems.org"
 # Add dependencies required to use your gem here.
 # Example:
 #   gem "activesupport", ">= 2.3.5"
-gem 'aws-sdk-v1'
+gem 'aws-sdk'
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ require 'open-uri-s3'
 Reading objects:
 
 ```ruby
-open('s3://my.bucket/public/hello') # returns AWS::S3::S3Object (quacks like IO)
+open('s3://my.bucket/public/hello') # returns Aws::S3::Object (quacks like IO)
 ```
 
 or a safer option (see [this post][open-uri-dangers] on the dangers of using open-uri with user input)

--- a/lib/open-uri-s3.rb
+++ b/lib/open-uri-s3.rb
@@ -1,16 +1,16 @@
-require 'aws-sdk-v1'
+require 'aws-sdk'
 require 'open-uri'
 require 'uri'
 
 module URI
   class S3 < Generic
 
-    # @return [AWS::S3::S3Object] S3 object (quacks like IO)
+    # @return [Aws::S3::Object] S3 object (quacks like IO)
     def open(*args)
-      s3 = ::AWS::S3.new
+      s3 = ::Aws::S3.new
       bucket = s3.buckets[self.hostname]
       if bucket.location_constraint
-        s3 = ::AWS::S3.new(s3_endpoint: "s3-#{bucket.location_constraint}.amazonaws.com")
+        s3 = ::Aws::S3.new(s3_endpoint: "s3-#{bucket.location_constraint}.amazonaws.com")
         bucket = s3.buckets[self.hostname]
       end
 

--- a/spec/lib/open-uri-s3_spec.rb
+++ b/spec/lib/open-uri-s3_spec.rb
@@ -10,7 +10,7 @@ describe URI::S3 do
   let(:object) { double('object', read: 'contents') }
 
   before do
-    allow(AWS::S3).to receive(:new).and_return(s3)
+    allow(Aws::S3).to receive(:new).and_return(s3)
   end
 
   describe "open" do


### PR DESCRIPTION
I don't think it can do much harm to upgrade the AWS SDK to version 2, which was released in the beginning of this year. There are some Blendle gems that rely on `open-uri-s3`, so this would allow us to get rid of the `aws-sdk-v1` dependency. Erik, let me know if you see any problems, or think this is a terrible idea.
