### PR TITLE
Issues introduced in upgrade to AWS SDK version 2

### DIFF
--- a/lib/open-uri-s3.rb
+++ b/lib/open-uri-s3.rb
@@ -7,15 +7,16 @@ module URI
 
     # @return [Aws::S3::Object] S3 object (quacks like IO)
     def open(*args)
-      s3 = ::Aws::S3.new
-      bucket = s3.buckets[self.hostname]
-      if bucket.location_constraint
-        s3 = ::Aws::S3.new(s3_endpoint: "s3-#{bucket.location_constraint}.amazonaws.com")
-        bucket = s3.buckets[self.hostname]
+      client = Aws::S3::Client.new
+      bucket_location = client.get_bucket_location(bucket: self.hostname)
+      location_constraint = bucket_location.data.location_constraint
+
+      if !location_constraint.empty?
+        client = Aws::S3::Client.new(region: location_constraint)
       end
 
       path = self.path[1..-1]
-      object = bucket.objects[path]
+      object = client.get_object(bucket: self.hostname, key: path).body
 
       if block_given?
         yield object

--- a/spec/lib/open-uri-s3_spec.rb
+++ b/spec/lib/open-uri-s3_spec.rb
@@ -10,7 +10,7 @@ describe URI::S3 do
   let(:object) { double('object', read: 'contents') }
 
   before do
-    allow(Aws::S3).to receive(:new).and_return(s3)
+    allow(Aws::S3::Client).to receive(:new).and_return(s3)
   end
 
   describe "open" do


### PR DESCRIPTION
This fixes several issues I introduced myself in https://github.com/eterps/open-uri-s3/pull/4 (upgrade to version 2 of AWS SDK) that basically caused the gem to break in most cases. For example, I wasn't able to read files from buckets that have a constraint on a location that is different from the default region. Sorry, Erik :disappointed: 

So, where I previously fetched a list of all buckets to determine the bucket location, I now explicitly request the bucket location using `get_bucket_location`.
